### PR TITLE
backup scripts - env, intermediate dirs, pg compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ For example,
 
 ```
 ls /mnt/volumes/backups/geonode-generic-sdffsdf/pg/20180419/:
--rw-r--r-- 1 root 184056 Apr 19 10:24 pg_dumpall-2018_04_19_1024_04.tar.gz
--rw-r--r-- 1 root 184056 Apr 19 10:24 pg_dumpall-2018_04_19_1024_09.tar.gz
+-rw-r--r-- 1 root 184056 Apr 19 10:24 pg_dumpall-2018_04_19_1024_04.gz
+-rw-r--r-- 1 root 184056 Apr 19 10:24 pg_dumpall-2018_04_19_1024_09.gz
 
 ls /mnt/volumes/backups/geonode-generic-sdffsdf/fs/20180419/:
 drwxr-xr-x 20 root   4096 Apr 19 10:22 data (there's data gs dir structure)

--- a/fs_backup.sh
+++ b/fs_backup.sh
@@ -6,6 +6,7 @@
 # TARGET_DIR - target dump dir including timestamp
 
 THIS_DIR=$(dirname $0)
+ENV_FILE=${THIS_DIR}/.env.cron
 
 # load env file and export values from it to shell
 export $(grep -v '^#' ${ENV_FILE} | xargs -d '\n')

--- a/fs_backup.sh
+++ b/fs_backup.sh
@@ -27,4 +27,9 @@ mkdir -p ${TARGET_DIR}
 
 rclone --config /root/rclone.conf copy local:/mnt/volumes/data/  dest:${TARGET_DIR}/data/
 rclone --config /root/rclone.conf copy local:/mnt/volumes/statics/  dest:${TARGET_DIR}/statics/
+
+# tar.gz files
 tar -czf ${TARGET_FILE} ${TARGET_DIR}/*
+
+# clean intermediate dirs
+rm -fr ${TARGET_DIR}/{data,statics}

--- a/pg_backup.sh
+++ b/pg_backup.sh
@@ -25,10 +25,11 @@ _TARGET_DIR=/${RANCHER_STACK:-geonode-generic}/pg/
 TARGET_DIR=${TARGET_DIR:-/mnt/volumes/backups/}/${_TARGET_DIR}/$(date +%Y%m%d)
 
 # all above + filename
-TARGET_FILE=${TARGET_DIR}/pg_dumpall-$(date '+%Y_%m_%d_%H%M_%S').tar.gz
+TARGET_FILE=${TARGET_DIR}/pg_dumpall-$(date '+%Y_%m_%d_%H%M_%S').gz
 
 mkdir -p ${TARGET_DIR}
 
 
 # we don't provide credentials nor db location, since it's comming from env
-pg_dumpall > ${TARGET_FILE}
+# dump will be compressed
+pg_dumpall | gzip -9 > ${TARGET_FILE}


### PR DESCRIPTION
fixes for #7 
* use .env.cron file in fs backup
* remove itermediate fs dirs
* compress pg dump